### PR TITLE
Fix audio callbacks for conversation screen

### DIFF
--- a/src/services/p2p/connection_manager.ts
+++ b/src/services/p2p/connection_manager.ts
@@ -43,6 +43,27 @@ let externalPeerFoundCallback: PeerFoundCallback | null = null
 let externalPeerLostCallback: PeerLostCallback | null = null
 
 ///////////////////////////////////////////////////////////////////////////////
+// Callback management
+///////////////////////////////////////////////////////////////////////////////
+export function updateCallbacks(params: {
+  onMessage?: MessageCallback | null
+  onConnected?: ConnectionSuccessCallback | null
+  onDisconnect?: DisconnectionCallback | null
+  onPeerFound?: PeerFoundCallback | null
+  onPeerLost?: PeerLostCallback | null
+}) {
+  if (params.onMessage !== undefined) externalMessageCallback = params.onMessage
+  if (params.onConnected !== undefined)
+    externalConnectSuccessCallback = params.onConnected
+  if (params.onDisconnect !== undefined)
+    externalDisconnectCallback = params.onDisconnect
+  if (params.onPeerFound !== undefined)
+    externalPeerFoundCallback = params.onPeerFound
+  if (params.onPeerLost !== undefined)
+    externalPeerLostCallback = params.onPeerLost
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // Binary-audio helper (iOS raw binary -> MPC; Android falls back to base-64)
 ///////////////////////////////////////////////////////////////////////////////
 export async function send_binary_audio_frame(


### PR DESCRIPTION
## Summary
- keep message callback active when LobbyScreen unmounts
- add `updateCallbacks` helper in connection manager
- register callbacks from LobbyScreen and ConversationScreen
- play audio frames even while LobbyScreen is not mounted

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc -p tsconfig.json` *(fails: missing type definitions)*
- `npm run lint` *(fails: ESLint config missing)*