### PR TITLE
Fix invalid bridge event emission

### DIFF
--- a/ios/EwonicAudioModule.m
+++ b/ios/EwonicAudioModule.m
@@ -226,6 +226,10 @@ RCT_EXPORT_METHOD(initialize:(NSInteger)sampleRate
                             RCTLogWarn(@"[TAP MAINQ DEBUG] Event NOT sent: mainQStrongSelf.bridge is NIL.");
                             return;
                         }
+                        if (![mainQStrongSelf.bridge isValid]) {
+                            RCTLogWarn(@"[TAP MAINQ DEBUG] Event NOT sent: mainQStrongSelf.bridge is NOT valid. Bridge description: %@", mainQStrongSelf.bridge);
+                            return;
+                        }
 
                         if (base64Data) {
                             // RCTLogInfo(@"[EwonicAudioModule Native Tap] SENDING onAudioData event (on main queue). Frames: %u, Base64Len: %lu", mainQStrongSelf.conversionOutputBuffer.frameLength, (unsigned long)base64Data.length);


### PR DESCRIPTION
## Summary
- guard against invalid RN bridge when sending audio events

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find configuration file)*