### PR TITLE
Fix BLE test button label

### DIFF
--- a/src/__tests__/integration/ble_p2p_integration.test.tsx
+++ b/src/__tests__/integration/ble_p2p_integration.test.tsx
@@ -3,15 +3,15 @@
  */
 
 import React from 'react';
-import { render, fireEvent, act, waitFor } from '@testing-library/react-native';
-import { BleManager } from 'react-native-ble-plx';
-import { Platform } from 'react-native';
+import {render, fireEvent, act, waitFor} from '@testing-library/react-native';
+import {BleManager} from 'react-native-ble-plx';
+import {Platform} from 'react-native';
 import LobbyScreen from '../../screens/LobbyScreen';
 
 jest.mock('react-native-ble-plx', () => ({
   BleManager: jest.fn().mockImplementation(() => ({
     startDeviceScan: jest.fn((_uuids, _opts, listener) => {
-      listener(null, { id: 'FAKE_DEVICE_ID', name: 'Mocked BLE Device' });
+      listener(null, {id: 'FAKE_DEVICE_ID', name: 'Mocked BLE Device'});
     }),
     stopDeviceScan: jest.fn(),
     connectToDevice: jest.fn(),
@@ -26,9 +26,9 @@ jest.mock('react-native-wifi-p2p', () => ({
   sendMessage: jest.fn(async () => Promise.resolve()),
   subscribeOnEvent: jest.fn((event, cb) => {
     if (event === 'connectionInfo') {
-      cb({ groupFormed: true });
+      cb({groupFormed: true});
     } else if (event === 'dataReceived') {
-      cb({ message: 'Mocked data message' });
+      cb({message: 'Mocked data message'});
     }
   }),
 }));
@@ -39,7 +39,7 @@ jest.mock('react-native-multipeer', () => ({
   send: jest.fn(async () => Promise.resolve()),
   on: jest.fn((event, cb) => {
     if (event === 'peerFound') {
-      cb({ id: 'FAKE_DEVICE_ID' });
+      cb({id: 'FAKE_DEVICE_ID'});
     }
   }),
 }));
@@ -52,22 +52,22 @@ describe('BLE + P2P Integration Test', () => {
   });
 
   afterAll(() => {
-    Object.defineProperty(Platform, 'OS', { value: originalPlatform });
+    Object.defineProperty(Platform, 'OS', {value: originalPlatform});
   });
 
   const setPlatform = (os: 'android' | 'ios') => {
-    Object.defineProperty(Platform, 'OS', { value: os });
+    Object.defineProperty(Platform, 'OS', {value: os});
   };
 
   it('should discover mock BLE device and trigger WifiP2p connect on Android', async () => {
     setPlatform('android');
 
-    const { getByText, queryByText } = render(<LobbyScreen />);
+    const {getByText, queryByText} = render(<LobbyScreen />);
 
-    fireEvent.press(getByText('START BLE DISCOVERY'));
+    fireEvent.press(getByText('Start BLE Discovery'));
 
     await waitFor(() =>
-      expect(queryByText('Mocked BLE Device - FAKE_DEVICE_ID')).toBeTruthy()
+      expect(queryByText('Mocked BLE Device - FAKE_DEVICE_ID')).toBeTruthy(),
     );
 
     await act(async () => {
@@ -82,12 +82,12 @@ describe('BLE + P2P Integration Test', () => {
   it('should discover mock BLE device and trigger Multipeer invite on iOS', async () => {
     setPlatform('ios');
 
-    const { getByText, queryByText } = render(<LobbyScreen />);
+    const {getByText, queryByText} = render(<LobbyScreen />);
 
     fireEvent.press(getByText('Start BLE Discovery')); // Corrected casing
 
     await waitFor(() =>
-      expect(queryByText('Mocked BLE Device - FAKE_DEVICE_ID')).toBeTruthy()
+      expect(queryByText('Mocked BLE Device - FAKE_DEVICE_ID')).toBeTruthy(),
     );
 
     await act(async () => {


### PR DESCRIPTION
## Summary
- fix capitalization of the BLE discovery button label in the integration test

## Testing
- `npm test` *(fails: jest not found)*