### PR TITLE
Fix audio event dispatch

### DIFF
--- a/ios/EwonicAudioModule.m
+++ b/ios/EwonicAudioModule.m
@@ -226,12 +226,6 @@ RCT_EXPORT_METHOD(initialize:(NSInteger)sampleRate
                             RCTLogWarn(@"[TAP MAINQ DEBUG] Event NOT sent: mainQStrongSelf.bridge is NIL.");
                             return;
                         }
-                        if (![mainQStrongSelf.bridge isValid]) {
-                            RCTLogWarn(@"[TAP MAINQ DEBUG] Event NOT sent: mainQStrongSelf.bridge is NOT valid. Bridge description: %@", mainQStrongSelf.bridge);
-                            // If the bridge is no longer valid, stop capturing to avoid repeated warnings
-                            [mainQStrongSelf stopCaptureInternal];
-                            return;
-                        }
 
                         if (base64Data) {
                             // RCTLogInfo(@"[EwonicAudioModule Native Tap] SENDING onAudioData event (on main queue). Frames: %u, Base64Len: %lu", mainQStrongSelf.conversionOutputBuffer.frameLength, (unsigned long)base64Data.length);


### PR DESCRIPTION
## Summary
- remove strict bridge validity check when dispatching audio events

## Testing
- `npm test` *(fails: jest: not found)*