### PR TITLE
Fix bridge invalidation during audio capture

### DIFF
--- a/ios/EwonicAudioModule.m
+++ b/ios/EwonicAudioModule.m
@@ -128,6 +128,11 @@ RCT_EXPORT_METHOD(initialize:(NSInteger)sampleRate
 {
     RCTLogInfo(@"[EwonicAudioModule Native] Initializing: Target SR=%ld, Tap BufSize=%ld frames, Target Ch=%ld, Target Depth=%ld",
                (long)sampleRate, (long)jsBufferSize, (long)channels, (long)bitDepth);
+    if (!self.bridge || ![self.bridge isValid]) {
+        RCTLogError(@"[EwonicAudioModule Native] Cannot initialize: bridge invalid or nil.");
+        reject(@"INIT_ERROR_BRIDGE_INVALID", @"React Native bridge is not valid", nil);
+        return;
+    }
     
     self.sampleRate = sampleRate;
     self.channels = channels;
@@ -227,8 +232,7 @@ RCT_EXPORT_METHOD(initialize:(NSInteger)sampleRate
                             return;
                         }
                         if (![mainQStrongSelf.bridge isValid]) {
-                            RCTLogWarn(@"[TAP MAINQ DEBUG] Event NOT sent: mainQStrongSelf.bridge is NOT valid. Bridge description: %@", mainQStrongSelf.bridge);
-                            // If the bridge is no longer valid, stop capturing to avoid repeated warnings
+                            RCTLogWarn(@"[TAP MAINQ DEBUG] Bridge invalid during event dispatch. Stopping capture. Bridge description: %@", mainQStrongSelf.bridge);
                             [mainQStrongSelf stopCaptureInternal];
                             return;
                         }
@@ -273,6 +277,11 @@ RCT_EXPORT_METHOD(startCapture:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
     RCTLogInfo(@"[EwonicAudioModule Native] startCapture called by JS.");
+    if (!self.bridge || ![self.bridge isValid]) {
+        RCTLogError(@"[EwonicAudioModule Native] Cannot start capture: bridge invalid or nil.");
+        reject(@"CAPTURE_ERROR_BRIDGE_INVALID", @"React Native bridge is not valid", nil);
+        return;
+    }
     if (!self.captureEngine) { reject(@"CAPTURE_ERROR_NO_ENGINE", @"CaptureEngine not initialized.", nil); return; }
     if (self.isRecording && self.captureEngine.isRunning) {
         RCTLogInfo(@"[EwonicAudioModule Native] Already recording and engine running.");


### PR DESCRIPTION
## Summary
- stop capture when event bridge becomes invalid
- prevent starting capture or initialization if the bridge is invalid

## Testing
- `npm test` *(fails: jest: not found)*