### PR TITLE
Fix invalid bridge by reacquiring active instance

### DIFF
--- a/ios/EwonicAudioModule.m
+++ b/ios/EwonicAudioModule.m
@@ -58,6 +58,21 @@ RCT_EXPORT_MODULE(); // Exports as "EwonicAudioModule"
     return @[@"onAudioData"];
 }
 
+// Attempt to find a currently active RCTBridge from the app's view hierarchy.
+- (RCTBridge *)findActiveBridge
+{
+    for (UIWindow *window in [UIApplication sharedApplication].windows) {
+        id rootVC = window.rootViewController;
+        if ([rootVC respondsToSelector:@selector(bridge)]) {
+            RCTBridge *possibleBridge = [rootVC performSelector:@selector(bridge)];
+            if (possibleBridge && [possibleBridge isValid]) {
+                return possibleBridge;
+            }
+        }
+    }
+    return nil;
+}
+
 - (void)dealloc {
     RCTLogInfo(@"[EwonicAudioModule Native] Deallocating: %@", self);
     if (self.isRecording) {
@@ -222,15 +237,17 @@ RCT_EXPORT_METHOD(initialize:(NSInteger)sampleRate
                             return;
                         }
 
-                        if (!mainQStrongSelf.bridge) {
-                            RCTLogWarn(@"[TAP MAINQ DEBUG] Event NOT sent: mainQStrongSelf.bridge is NIL.");
-                            return;
-                        }
-                        if (![mainQStrongSelf.bridge isValid]) {
-                            RCTLogWarn(@"[TAP MAINQ DEBUG] Event NOT sent: mainQStrongSelf.bridge is NOT valid. Bridge description: %@", mainQStrongSelf.bridge);
-                            // If the bridge is no longer valid, stop capturing to avoid repeated warnings
-                            [mainQStrongSelf stopCaptureInternal];
-                            return;
+                        if (!mainQStrongSelf.bridge || ![mainQStrongSelf.bridge isValid]) {
+                            RCTLogWarn(@"[TAP MAINQ DEBUG] Bridge missing or invalid when sending event. Attempting recovery...");
+                            RCTBridge *recovered = [mainQStrongSelf findActiveBridge];
+                            if (recovered) {
+                                RCTLogInfo(@"[TAP MAINQ DEBUG] Acquired new bridge instance. Continuing event dispatch.");
+                                mainQStrongSelf.bridge = recovered;
+                            } else {
+                                RCTLogError(@"[TAP MAINQ DEBUG] Failed to recover a valid bridge. Stopping capture.");
+                                [mainQStrongSelf stopCaptureInternal];
+                                return;
+                            }
                         }
 
                         if (base64Data) {


### PR DESCRIPTION
## Summary
- add helper to locate active RCTBridge
- attempt bridge recovery when sending audio events

## Testing
- `npm test` *(fails: jest: not found)*